### PR TITLE
Find composer.json correctly when run from PHAR

### DIFF
--- a/src/ConventionalCommits/Configuration/FinderTool.php
+++ b/src/ConventionalCommits/Configuration/FinderTool.php
@@ -170,7 +170,7 @@ trait FinderTool
     {
         $validator = new Validator();
         $schema = $validator->loader()->loadObjectSchema(
-            (object) json_decode((string) file_get_contents((string) realpath(__DIR__ . '/../../../schema.json'))),
+            (object) json_decode((string) file_get_contents(dirname(dirname(dirname(__DIR__))) . '/schema.json')),
         );
         $result = $validator->validate($config, $schema);
 

--- a/src/ConventionalCommits/Configuration/FinderTool.php
+++ b/src/ConventionalCommits/Configuration/FinderTool.php
@@ -28,6 +28,7 @@ use JsonException;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Validator;
+use Phar;
 use Ramsey\ConventionalCommits\Exception\ComposerNotFound;
 use Ramsey\ConventionalCommits\Exception\InvalidArgument;
 use Ramsey\ConventionalCommits\Exception\InvalidValue;
@@ -38,6 +39,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 use function dirname;
 use function file_get_contents;
+use function getcwd;
 use function gettype;
 use function implode;
 use function is_array;
@@ -203,6 +205,29 @@ trait FinderTool
      */
     private function findComposerJson(Filesystem $filesystem): string
     {
+        $path = Phar::running() ? getcwd() : $this->getAutoloaderPath($filesystem);
+
+        do {
+            if ($filesystem->exists((string) $path . '/composer.json')) {
+                $composerJson = (string) realpath((string) $path . '/composer.json');
+            }
+
+            // We have reached the root directory.
+            if (dirname((string) $path) === $path) {
+                throw new ComposerNotFound('Could not find composer.json.');
+            }
+
+            $path = dirname((string) $path);
+        } while (!isset($composerJson));
+
+        return (string) $composerJson;
+    }
+
+    /**
+     * @throws ComposerNotFound when unable to find the autoload.php file
+     */
+    private function getAutoloaderPath(Filesystem $filesystem): string
+    {
         // We do this as a way to determine where the package is installed, so
         // we can determine which composer.json to use. This isn't fool-proof,
         // since we can't detect when config.vendor-dir puts the vendor
@@ -231,19 +256,6 @@ trait FinderTool
             );
         }
 
-        do {
-            if ($filesystem->exists((string) $path . '/composer.json')) {
-                $composerJson = (string) realpath((string) $path . '/composer.json');
-            }
-
-            // We have reached the root directory.
-            if (dirname((string) $path) === $path) {
-                throw new ComposerNotFound('Could not find composer.json.');
-            }
-
-            $path = dirname((string) $path);
-        } while (!isset($composerJson));
-
-        return (string) $composerJson;
+        return (string) $path;
     }
 }

--- a/src/ConventionalCommits/Configuration/FinderTool.php
+++ b/src/ConventionalCommits/Configuration/FinderTool.php
@@ -222,7 +222,7 @@ trait FinderTool
             $path = dirname((string) $path);
         } while ($composerJson === '');
 
-        return (string) $composerJson;
+        return $composerJson;
     }
 
     /**

--- a/tests/expect/config_04.exp
+++ b/tests/expect/config_04.exp
@@ -15,7 +15,7 @@ spawn ../../bin/conventional-commits config --config ../configs/config-04.json -
 match_max 100000
 
 expect -exact "\r
-\[33mIn FinderTool.php line 121:\[39m\r
+\[33mIn FinderTool.php line 123:\[39m\r
 \[37;41m                                                                                         \[39;49m\r
 \[37;41m  Expected a configuration array in ../configs/config-04.json; received string instead.  \[39;49m\r
 \[37;41m                                                                                         \[39;49m\r

--- a/tests/expect/config_05.exp
+++ b/tests/expect/config_05.exp
@@ -15,7 +15,7 @@ spawn ../../bin/conventional-commits config --config ../configs/config-05.json -
 match_max 100000
 
 expect -exact "\r
-\[33mIn FinderTool.php line 195:\[39m\r
+\[33mIn FinderTool.php line 197:\[39m\r
 \[37;41m                                                                                             \[39;49m\r
 \[37;41m  Invalid /types value found in configuration: The data (string) must match the type: array  \[39;49m\r
 \[37;41m                                                                                             \[39;49m\r


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
When compiling a phar and running it, the command fails because it cannot find a composer.json. This is because it tries to search for the composer.json within the generated phar file and it doesn't find one. This change handles the case when the script is running as a phar file and correctly finds the path to composer.json.

## Motivation and context
This is required in preparation for supporting a PHAR archive which is discussed in #25.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To test this, I generated a phar using `box` and moved it to my `/usr/local/bin` directory. Then, I run the command `conventional-commits` in a directory of a PHP project. Without the fix, I get this error:
```
❯ ./conventional-commits.phar config

In FinderTool.php line 241:

  Could not find composer.json.


config [--config CONFIG] [--dump]
```

I repeated the test after writing the fix and the command output was as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
