### PR TITLE
Fix OSX PHP8.1 lowest

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
     <php>
         <!-- Turn off console color output for easier testing of output strings. -->
         <env name="NO_COLOR" value="1"/>
+        <ini name="error_reporting" value="24575"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
PHP unit converts the deprecation errors into failures.

## Description

Looks like this fixes OSX with php8.1 lowest failure...

## Motivation and context

You asked what was wrong and for a fix.

https://stackoverflow.com/a/61288824/1548557

Fixes #35 

## How has this been tested?

Ran the actions on a forked branch of `main`
https://github.com/Lewiscowles1986/conventional-commits/actions/runs/1650777701

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
