### PR TITLE
Add support for building PHAR files and associated tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -220,8 +220,8 @@ jobs:
       - name: "Build PHAR file"
         shell: "bash"
         run: |
-          phive install humbug/box --force-accept-unsigned
-          ./tools/box build
+          phive install humbug/box
+          ./tools/box compile
 
       - name: "Run functional tests on the phar file"
         shell: "bash"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -220,7 +220,7 @@ jobs:
       - name: "Build PHAR file"
         shell: "bash"
         run: |
-          phive install humbug/box
+          phive install humbug/box --trust-gpg-keys 0x2DF45277AEF09A2F
           ./tools/box compile
 
       - name: "Run functional tests on the phar file"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -195,10 +195,32 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "none"
+          tools: "phive"
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"
 
       - name: "Run functional tests"
+        shell: "bash"
+        run: "composer test-functional"
+
+      - name: "Cleanup to prepare for PHAR tests"
+        shell: "bash"
+        run: |
+          rm -rf vendor/
+          phive install humbug/box --force-accept-unsigned
+          sed -i .bak 's#\.\./\.\./bin/conventional-commits #../../bin/conventional-commits.phar #g' tests/expect/*.exp
+
+      - name: "Install dependencies (Composer)"
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--no-dev"
+
+      - name: "Build PHAR file"
+        shell: "bash"
+        run: |
+          box build
+
+      - name: "Run functional tests on the phar file"
         shell: "bash"
         run: "composer test-functional"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           rm -rf vendor/
           phive install humbug/box --force-accept-unsigned
-          sed -i .bak 's#\.\./\.\./bin/conventional-commits #../../bin/conventional-commits.phar #g' tests/expect/*.exp
+          sed -i 's#\.\./\.\./bin/conventional-commits #../../bin/conventional-commits.phar #g' tests/expect/*.exp
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -208,8 +208,6 @@ jobs:
         shell: "bash"
         run: |
           rm -rf vendor/
-          phive install humbug/box --force-accept-unsigned
-          sed -i 's#\.\./\.\./bin/conventional-commits #../../bin/conventional-commits.phar #g' tests/expect/*.exp
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"
@@ -219,8 +217,11 @@ jobs:
       - name: "Build PHAR file"
         shell: "bash"
         run: |
-          box build
+          phive install humbug/box --force-accept-unsigned
+          ./tools/box build
 
       - name: "Run functional tests on the phar file"
         shell: "bash"
-        run: "composer test-functional"
+        run: |
+          sed -i 's#\.\./\.\./bin/conventional-commits #../../bin/conventional-commits.phar #g' tests/expect/*.exp
+          composer test-functional

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -220,7 +220,7 @@ jobs:
       - name: "Build PHAR file"
         shell: "bash"
         run: |
-          phive install humbug/box --trust-gpg-keys 0x2DF45277AEF09A2F
+          phive install humbug/box:"${{ matrix.php-version == '8.1' && '^4.1' || '^3.16' }}" --trust-gpg-keys 0x2DF45277AEF09A2F
           ./tools/box compile
 
       - name: "Run functional tests on the phar file"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor/
 /.box_dump/
 /bin/conventional-commits.phar
+/tools/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /phpcs.xml
 /phpunit.xml
 /vendor/
+/.box_dump/
+/bin/conventional-commits.phar

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="humbug/box" version="^4.1.0" installed="4.1.0" location="./tools/box" copy="false"/>
+</phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="humbug/box" version="^4.1.0" installed="4.1.0" location="./tools/box" copy="false"/>
+  <phar name="humbug/box" version="^3.16 || ^4.1" installed="4.1.0" location="./tools/box" copy="false"/>
 </phive>

--- a/box.json
+++ b/box.json
@@ -1,0 +1,3 @@
+{
+    "files": ["schema.json"]
+}


### PR DESCRIPTION
## Description
This change adds a box configuration file so that we can build PHAR's as discussed in #25. There is also associated CI changes to test the PHAR file.

## Motivation and context
This was discussed in #25.

## How has this been tested?
I modified the expect files to run the PHAR file instead of entrypoint and ran the tests. All the tests passed. I also tested the PHAR file manually. This change is also implemented in the CI workflow.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
