### PR TITLE
Fix composer partial load

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,7 @@
 <psalm xmlns="https://getpsalm.org/schema/config"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-       totallyTyped="true"
+       errorLevel="1"
        cacheDirectory="./build/cache/psalm"
        errorBaseline="./psalm-baseline.xml">
 

--- a/src/ConventionalCommits/Configuration/FinderTool.php
+++ b/src/ConventionalCommits/Configuration/FinderTool.php
@@ -97,7 +97,7 @@ trait FinderTool
         $composerIO = new ConsoleIO($input, $output, new HelperSet());
         $composerFactory = new Factory();
 
-        return $composerFactory->createComposer($composerIO, $composerJson, true, null, false);
+        return $composerFactory->createComposer($composerIO, $composerJson, true, null, true);
     }
 
     /**

--- a/tests/ConventionalCommits/Configuration/FinderToolTest.php
+++ b/tests/ConventionalCommits/Configuration/FinderToolTest.php
@@ -176,6 +176,7 @@ class FinderToolTest extends TestCase
 
     public function testGetComposerFindsComposerJsonForCurrentProject(): void
     {
+        $this->output->shouldReceive('isDebug');
         $this->output->allows()->getVerbosity()->andReturn(OutputInterface::VERBOSITY_QUIET);
         $filesystem = new Filesystem();
 


### PR DESCRIPTION
The actual version of this package does not work with the next version of composer/composer.

Running the unit tests will return this output : 

> TypeError: Ramsey\CaptainHook\PrepareConventionalCommit::getComposer(): Return value must be of type Composer\Composer, Composer\PartialComposer returned

## Description

The fullyLoaded attribute was explicitly set to false, so I changed it to true in order to get a `Composer\Composer` instance instead of a `Composer\PartialComposer` one.

You can also refer to this pull request to get more context about this change in composer : https://github.com/composer/composer/pull/10547.

It won't introduce any breaking changes (the fullyLoaded argument already existed in composer:^1.10) and it should be compatible with all the php versions supported by this package.

You can find all the internal changes for composer 2.3 here : https://github.com/composer/composer/issues/10573.

I also updated the `totallyTyped` attribute from the Psalm config since it's deprecated and was raising an error : https://psalm.dev/docs/running_psalm/configuration/#totallytyped. I'm not familiar with Psalm but it should have the same behaviour as before.

## Motivation and context

We need this change to make this package works with the next version of composer/composer (version 2.3.0-RC2 at the moment).

This package just doesn't work for those who are already using the 2.3.0.

## How has this been tested?

I didn't add any new tests as the ones already present cover this change : https://github.com/ramsey/conventional-commits/blob/1.3.0/tests/ConventionalCommits/Configuration/FinderToolTest.php#L185.

I also made some some manual tests locally (php8.0 and php8.1) and it works fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
