### PR TITLE
Add a validate command to CLI to validate commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ messages according to Conventional Commits, enter the following in your console:
 ./vendor/bin/conventional-commits prepare
 ```
 
+You can also validate the commit message using the following command:
+
+``` bash
+./vendor/bin/conventional-commits validate "[commit message]"
+```
+
+If you don't provide a commit message in the command line, the command will
+prompt you for it.
+
 To see all the features of the console command, enter:
 
 ``` bash

--- a/bin/conventional-commits
+++ b/bin/conventional-commits
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 use Ramsey\ConventionalCommits\Console\Command\ConfigCommand;
 use Ramsey\ConventionalCommits\Console\Command\PrepareCommand;
+use Ramsey\ConventionalCommits\Console\Command\ValidateCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
@@ -66,5 +67,6 @@ use Symfony\Component\Console\Input\InputOption;
 
     $application->add(new ConfigCommand());
     $application->add(new PrepareCommand());
+    $application->add(new ValidateCommand());
     $application->run(new ArgvInput($argv));
 })($argv);

--- a/src/ConventionalCommits/Console/Command/ValidateCommand.php
+++ b/src/ConventionalCommits/Console/Command/ValidateCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of ramsey/conventional-commits
+ *
+ * ramsey/conventional-commits is open source software: you can distribute it
+ * and/or modify it under the terms of the MIT License (the "License"). You may
+ * not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Ramsey\ConventionalCommits\Console\Command;
+
+use Ramsey\ConventionalCommits\Console\Question\MessageQuestion;
+use Ramsey\ConventionalCommits\Console\SymfonyStyleFactory;
+use Ramsey\ConventionalCommits\Exception\ConventionalException;
+use Ramsey\ConventionalCommits\Parser;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * A console command that validates a commit message as per the
+ * Conventional Commits specification
+ */
+class ValidateCommand extends BaseCommand
+{
+    private SymfonyStyleFactory $styleFactory;
+
+    public function __construct(?SymfonyStyleFactory $styleFactory = null)
+    {
+        parent::__construct('validate');
+
+        $this->styleFactory = $styleFactory ?? new SymfonyStyleFactory();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Validate a commit message to ensure it conforms to Conventional Commits')
+            ->setHelp(
+                'This command validates a commit message according to the '
+                . 'Conventional Commits specification. For more information, '
+                . 'see https://www.conventionalcommits.org.',
+            )
+            ->addArgument(
+                'message',
+                InputArgument::OPTIONAL,
+                'The commit message to be validated',
+            )
+            ->addOption(
+                'config',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to a file containing Conventional Commits configuration',
+            );
+    }
+
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        $console = $this->styleFactory->factory($input, $output);
+
+        /** @var string|null $message */
+        $message = $input->getArgument('message');
+        if ($message === null) {
+            $console->title('Validate Commit Message');
+            /** @var string|null $message */
+            $message = $console->askQuestion(new MessageQuestion($this->getConfiguration()));
+        }
+
+        if ($message === null) {
+            $console->error('No commit message was provided');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $parser = new Parser($this->getConfiguration());
+            $parser->parse($message);
+        } catch (ConventionalException $exception) {
+            $console->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $console->section('Commit Message');
+        $console->block($message);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/ConventionalCommits/Console/Command/ValidateCommand.php
+++ b/src/ConventionalCommits/Console/Command/ValidateCommand.php
@@ -75,7 +75,10 @@ class ValidateCommand extends BaseCommand
         $message = $input->getArgument('message');
         if ($message === null) {
             $console->title('Validate Commit Message');
-            /** @var string|null $message */
+            /**
+             * @psalm-suppress ReservedWord
+             * @var string|null $message
+             */
             $message = $console->askQuestion(new MessageQuestion($this->getConfiguration()));
         }
 

--- a/src/ConventionalCommits/Console/Question/MessageQuestion.php
+++ b/src/ConventionalCommits/Console/Question/MessageQuestion.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of ramsey/conventional-commits
+ *
+ * ramsey/conventional-commits is open source software: you can distribute it
+ * and/or modify it under the terms of the MIT License (the "License"). You may
+ * not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Ramsey\ConventionalCommits\Console\Question;
+
+use Ramsey\ConventionalCommits\Configuration\Configurable;
+use Ramsey\ConventionalCommits\Configuration\ConfigurableTool;
+use Ramsey\ConventionalCommits\Configuration\Configuration;
+use Symfony\Component\Console\Question\Question;
+
+use function method_exists;
+use function trim;
+
+/**
+ * A prompt that accepts long-form body content for the commit message
+ */
+class MessageQuestion extends Question implements Configurable
+{
+    use ConfigurableTool;
+
+    public function __construct(?Configuration $configuration = null)
+    {
+        if (method_exists($this, 'setMultiline')) {
+            $this->setMultiline(true); // @codeCoverageIgnore
+        }
+
+        $this->configuration = $configuration;
+
+        parent::__construct(
+            'Enter the commit message to be validated',
+        );
+    }
+
+    public function getValidator(): callable
+    {
+        return function (?string $answer): ?string {
+            if (trim((string) $answer) === '') {
+                return null;
+            }
+
+            return $answer;
+        };
+    }
+}

--- a/tests/ConventionalCommits/Console/Command/ValidateCommandTest.php
+++ b/tests/ConventionalCommits/Console/Command/ValidateCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ramsey\Test\ConventionalCommits\Console\Command;
+
+use Hamcrest\Core\IsInstanceOf;
+use Mockery\MockInterface;
+use Ramsey\ConventionalCommits\Console\Command\ValidateCommand;
+use Ramsey\ConventionalCommits\Console\Question\MessageQuestion;
+use Ramsey\ConventionalCommits\Console\SymfonyStyleFactory;
+use Ramsey\Test\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ValidateCommandTest extends TestCase
+{
+    public function testCommandName(): void
+    {
+        $command = new ValidateCommand();
+
+        $this->assertSame('validate', $command->getName());
+    }
+
+    public function testRunWithNoArgs(): void
+    {
+        $input = new StringInput('');
+        $output = new NullOutput();
+
+        $console = $this->mockery(SymfonyStyle::class);
+
+        $console->expects()->title('Validate Commit Message');
+
+        $console
+            ->expects()
+            ->askQuestion(new IsInstanceOf(MessageQuestion::class))
+            ->andReturn(null);
+
+        $console
+            ->expects()
+            ->error('No commit message was provided');
+
+        /** @var SymfonyStyleFactory & MockInterface $factory */
+        $factory = $this->mockery(SymfonyStyleFactory::class);
+        $factory->expects()->factory($input, $output)->andReturn($console);
+
+        $command = new ValidateCommand($factory);
+        $command->run($input, $output);
+    }
+
+    public function testRunWithInvalidCliArg(): void
+    {
+        $input = new StringInput("'some issue'");
+        $output = new NullOutput();
+
+        $console = $this->mockery(SymfonyStyle::class);
+
+        $console->expects()->title('Validate Commit Message')->never();
+
+        $console
+            ->expects()
+            ->askQuestion(new IsInstanceOf(MessageQuestion::class))
+            ->never();
+
+        $console
+            ->expects()
+            ->error('Could not find a valid Conventional Commits message.');
+
+        /** @var SymfonyStyleFactory & MockInterface $factory */
+        $factory = $this->mockery(SymfonyStyleFactory::class);
+        $factory->expects()->factory($input, $output)->andReturn($console);
+
+        $command = new ValidateCommand($factory);
+        $command->run($input, $output);
+    }
+
+    public function testRunWithValidCliArg(): void
+    {
+        $input = new StringInput("'fix: some issue'");
+        $output = new NullOutput();
+
+        $console = $this->mockery(SymfonyStyle::class);
+
+        $console->expects()->title('Validate Commit Message')->never();
+
+        $console
+            ->expects()
+            ->askQuestion(new IsInstanceOf(MessageQuestion::class))
+            ->never();
+
+        $console->expects()->section('Commit Message');
+        $console->expects()->block('fix: some issue');
+
+        /** @var SymfonyStyleFactory & MockInterface $factory */
+        $factory = $this->mockery(SymfonyStyleFactory::class);
+        $factory->expects()->factory($input, $output)->andReturn($console);
+
+        $command = new ValidateCommand($factory);
+        $command->run($input, $output);
+    }
+
+    public function testRunWithInvalidInput(): void
+    {
+        $input = new StringInput('');
+        $output = new NullOutput();
+
+        $console = $this->mockery(SymfonyStyle::class);
+
+        $console->expects()->title('Validate Commit Message');
+
+        $console
+            ->expects()
+            ->askQuestion(new IsInstanceOf(MessageQuestion::class))
+            ->andReturn('some issue');
+
+        $console
+            ->expects()
+            ->error('Could not find a valid Conventional Commits message.');
+
+        /** @var SymfonyStyleFactory & MockInterface $factory */
+        $factory = $this->mockery(SymfonyStyleFactory::class);
+        $factory->expects()->factory($input, $output)->andReturn($console);
+
+        $command = new ValidateCommand($factory);
+        $command->run($input, $output);
+    }
+
+    public function testRunWithValidInput(): void
+    {
+        $input = new StringInput('');
+        $output = new NullOutput();
+
+        $console = $this->mockery(SymfonyStyle::class);
+
+        $console->expects()->title('Validate Commit Message');
+
+        $console
+            ->expects()
+            ->askQuestion(new IsInstanceOf(MessageQuestion::class))
+            ->andReturn('fix: some issue');
+
+        $console->expects()->section('Commit Message');
+        $console->expects()->block('fix: some issue');
+
+        /** @var SymfonyStyleFactory & MockInterface $factory */
+        $factory = $this->mockery(SymfonyStyleFactory::class);
+        $factory->expects()->factory($input, $output)->andReturn($console);
+
+        $command = new ValidateCommand($factory);
+        $command->run($input, $output);
+    }
+}

--- a/tests/ConventionalCommits/Console/Question/MessageQuestionTest.php
+++ b/tests/ConventionalCommits/Console/Question/MessageQuestionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ramsey\Test\ConventionalCommits\Console\Question;
+
+use Ramsey\ConventionalCommits\Console\Question\MessageQuestion;
+use Ramsey\Test\TestCase;
+
+class MessageQuestionTest extends TestCase
+{
+    public function testQuestion(): void
+    {
+        $question = new MessageQuestion();
+
+        $this->assertSame(
+            'Enter the commit message to be validated',
+            $question->getQuestion(),
+        );
+        $this->assertNull($question->getDefault());
+    }
+
+    public function testValidatorReturnsNullForEmptyString(): void
+    {
+        $question = new MessageQuestion();
+        $validator = $question->getValidator();
+
+        $this->assertNull($validator(' '));
+    }
+
+    public function testValidatorReturnsNullForNull(): void
+    {
+        $question = new MessageQuestion();
+        $validator = $question->getValidator();
+
+        $this->assertNull($validator(null));
+    }
+
+    public function testValidatorReturnsBody(): void
+    {
+        $question = new MessageQuestion();
+        $validator = $question->getValidator();
+
+        /** @var string $message */
+        $message = $validator('this is a message');
+
+        $this->assertSame('this is a body', $message);
+    }
+}

--- a/tests/ConventionalCommits/Console/Question/MessageQuestionTest.php
+++ b/tests/ConventionalCommits/Console/Question/MessageQuestionTest.php
@@ -44,6 +44,6 @@ class MessageQuestionTest extends TestCase
         /** @var string $message */
         $message = $validator('this is a message');
 
-        $this->assertSame('this is a body', $message);
+        $this->assertSame('this is a message', $message);
     }
 }


### PR DESCRIPTION
## Description
As discussed in https://github.com/ramsey/conventional-commits/issues/57#issuecomment-1191824713, this PR adds a command to validate a commit message

## Motivation and context
More details in #57 and #25.

## How has this been tested?
So far, I have added a few tests and mainly tested this manually. This PR is WIP and I will add more tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
