### PR TITLE
fix: phpstan error when memory_limit is 128M

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
             "@dev:analyze:phpstan",
             "@dev:analyze:psalm"
         ],
-        "dev:analyze:phpstan": "phpstan analyse --ansi",
+        "dev:analyze:phpstan": "phpstan analyse --ansi --memory-limit 256M",
         "dev:analyze:psalm": "psalm",
         "dev:build:clean": "git clean -fX build/",
         "dev:lint": [


### PR DESCRIPTION
## Description
PHPStan results in a memory limit error when I run on a machine with default the default memory_limit of 128M (or it could be my OS). This small change ensures that PHPStan works fine on machines with this limit.

## Motivation and context
My CLI runs on the default memory_limit of 128M and I noticed these errors in development. I could set the memory_limit in my ini file, of course, but this is inconvenient. Besides, I believe the change here is simple and should not affect anything else.

## How has this been tested?
By manually running `composer dev:analyze:phpstan` after clearing the result cache (`vendor/bin/phpstan clear-result-cache`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
